### PR TITLE
Cloud auto join aws

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ Playbook to trigger client join for Consul Servers deployed from [Terraform AWS 
     - name: Install Hashicorp Consul Client role
       hosts: clients
       roles:
-        - role: consul
-          consul_command_opts: ""
-          consul_start_join_enabled: "false"
-          consul_retry_join_enabled: "true"
-          consul_datacenter: "us-east-1"
+      - role: consul
+        consul_command_opts: ""
+        consul_start_join_enabled: "false"
+        consul_retry_join_enabled: "true"
+        consul_datacenter: "us-east-1"
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Slightly more complex server and client
         consul_systemd_enabled: "false"
         consul_datacenter: "dc1"
 
-Playbook to trigger client join for Consul Servers deployed from [https://github.com/hashicorp/terraform-aws-consul/](https://github.com/hashicorp/terraform-aws-consul/)
+Playbook to trigger client join for Consul Servers deployed from [Terraform AWS Consul](https://github.com/hashicorp/terraform-aws-consul/)
 
     - name: Install Hashicorp Consul Client role
       hosts: clients

--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ Slightly more complex server and client
         consul_systemd_enabled: "false"
         consul_datacenter: "dc1"
 
+Playbook to trigger client join for Consul Servers deployed from [https://github.com/hashicorp/terraform-aws-consul/](https://github.com/hashicorp/terraform-aws-consul/)
+
+    - name: Install Hashicorp Consul Client role
+      hosts: clients
+      roles:
+        - role: consul
+          consul_command_opts: ""
+          consul_start_join_enabled: "false"
+          consul_retry_join_enabled: "true"
+          consul_datacenter: "us-east-1"
+
 ## License
 
 BSD

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,6 +51,8 @@ consul_client_addr: "0.0.0.0"
 consul_wan_join_enabled: false
 consul_wan_join_addr: ""
 consul_lan_join_addr: "0.0.0.0"
+consul_retry_join_enabled: "false"
+consul_start_join_enabled: "enabled"
 consul_datacenter: "dc1"
 consul_http_port: "8500"
 consul_dns_port: "8600"

--- a/templates/consul.hcl.j2
+++ b/templates/consul.hcl.j2
@@ -5,6 +5,11 @@
   {% if consul_wan_join_enabled %}
   "start_join_wan": ["{{ consul_wan_join_addr }}"],
   {% endif %}
+  {% if consul_start_join_enabled %}
   "start_join": ["{{ consul_lan_join_addr }}"],
+  {% endif %}
+  {% if consul_retry_join_enabled %}
+  "retry_join": ["provider=aws tag_key=consul-servers tag_value=consul"],
+  {% endif %}
   "datacenter": "{{ consul_datacenter }}"
 }


### PR DESCRIPTION
Allow consul clients to automatically join AWS servers deployed via the [Terraform AWS Consul](https://github.com/hashicorp/terraform-aws-consul/) module.